### PR TITLE
Enforce autofocus on scanner and enhance barcode input

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.google.devtools.ksp.KspExperimental
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.compose.internal.utils.getLocalProperty
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
@@ -98,7 +97,7 @@ kotlin {
     }
 }
 
-val version: String = "1.0.0"
+val version: String = "1.0.1"
 
 android {
     namespace = "com.cocot3ro.gh.almacen"

--- a/composeApp/src/androidMain/kotlin/com/cocot3ro/gh/almacen/ui/screens/almacen/EditBottomSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/cocot3ro/gh/almacen/ui/screens/almacen/EditBottomSheet.kt
@@ -82,7 +82,7 @@ import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import gh_almacen.composeapp.generated.resources.Res
 import gh_almacen.composeapp.generated.resources.add_a_photo_24dp
-import gh_almacen.composeapp.generated.resources.barcode_scanner_48dp
+import gh_almacen.composeapp.generated.resources.barcode_reader_24dp
 import gh_almacen.composeapp.generated.resources.broken_image_24dp
 import gh_almacen.composeapp.generated.resources.photo_size_select_small_24dp
 import gh_almacen.composeapp.generated.resources.playlist_add_24dp
@@ -331,7 +331,9 @@ fun EditBottomSheet(
                     )
 
                 val onAppendBarcode: () -> Unit = remember {
-                    {
+                    onAppendBarcode@ {
+                        if (viewModel.newBarcodeInput.toLongOrNull() == null) return@onAppendBarcode
+
                         focusManager.clearFocus()
 
                         val result: Boolean =
@@ -363,13 +365,16 @@ fun EditBottomSheet(
                         ) {
                             Icon(
                                 modifier = Modifier.size(24.dp),
-                                imageVector = vectorResource(Res.drawable.barcode_scanner_48dp),
+                                imageVector = vectorResource(Res.drawable.barcode_reader_24dp),
                                 contentDescription = null
                             )
                         }
                     },
                     trailingIcon = {
-                        IconButton(onClick = onAppendBarcode) {
+                        IconButton(
+                            onClick = onAppendBarcode,
+                            enabled = viewModel.newBarcodeInput.toLongOrNull() != null
+                        ) {
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = null


### PR DESCRIPTION
This commit introduces several improvements:

- **ScannerActivity:**
    - Forces autofocus to the center of the screen upon initialization.
    - Allows users to re-focus by tapping on the screen.
- **EditBottomSheet:**
    - Replaces the barcode scanner icon.
    - Validates that the new barcode input is a valid number before appending.
    - Disables the "append barcode" button if the input is not a valid number.
- **Build:**
    - Increments the app version to 1.0.1.