### PR TITLE
Fix: Toast message in CargaDescargaScreen

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -97,7 +97,7 @@ kotlin {
     }
 }
 
-val version: String = "1.1.0"
+val version: String = "1.1.1"
 
 android {
     namespace = "com.cocot3ro.gh.almacen"

--- a/composeApp/src/androidMain/kotlin/com/cocot3ro/gh/almacen/ui/screens/cargadescarga/CargaDescargaScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/cocot3ro/gh/almacen/ui/screens/cargadescarga/CargaDescargaScreen.kt
@@ -512,7 +512,7 @@ fun CargaDescargaScreen(
             UiState.Loading -> Unit
 
             is UiState.Success<*> -> {
-                Toast.makeText(context, "Stock añadido", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "Stock modificado", Toast.LENGTH_SHORT).show()
 
                 viewModel.dismiss()
                 onNavigateBack()


### PR DESCRIPTION
The toast message for a successful stock modification was incorrectly displaying "Stock añadido". This has been corrected to "Stock modificado".

The app version has also been incremented to 1.1.1.